### PR TITLE
Making the constructor private

### DIFF
--- a/src/main/java/ie/ucd/murmur/MurmurHash.java
+++ b/src/main/java/ie/ucd/murmur/MurmurHash.java
@@ -17,6 +17,8 @@ package ie.ucd.murmur;
  *
  */
 public final class MurmurHash {
+	
+	private MurmurHash() {}
 
 	/** Generates 32 bit hash from byte array of the given length and
 	 * seed.


### PR DESCRIPTION
Hi, 

Just a small trick: making the constructor private so that no one can create an object from this this utility class. A small feature, but it can even make the "final" keyword redundant (but it's worth keep it anyway, I guess).
