### PR TITLE
Fixed issue where "mvn test" wouldn't run any tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,21 +106,6 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.8.1</version>
-                <configuration>
-                    <useSystemClassLoader>false</useSystemClassLoader>
-                    <argLine>-Xmx1024m</argLine>
-                    <includes>
-                        <include>**/*Spec.java</include>
-                    </includes>
-                    <excludes>
-                        <exclude>**/*Test.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
         </plugins>
 
         <extensions>


### PR DESCRIPTION
It looks as though the surefire-plugin has overridden the maven defaults of how to find test classes. I've restored the surefire defaults so that the test class is now being picked up.
